### PR TITLE
Update db replica's hostname

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def main ( args ):
 
 class Run:
 	def __init__( self, wiki, dry_run ):
-		host = '127.0.0.1' if dry_run else wiki + 'wiki.labsdb'
+		host = '127.0.0.1' if dry_run else wiki + 'wiki.db.svc.eqiad.wmflabs'
 		port = credentials.get( 'port', 3306 )
 		self.db = pymysql.connect( host = host, user = credentials['user'], passwd = credentials['pass'], db = wiki + 'wiki_p', port = port )
 		self.site = mwclient.Site( wiki + '.wikipedia.org' )


### PR DESCRIPTION
Remove db alias (deprecated) and use the new hostname to conform with
the Wiki Replicas 2020 Redesign.
See: https://wikitech.wikimedia.org/wiki/News/Wiki_Replicas_2020_Redesign

Bug: https://phabricator.wikimedia.org/T275817