### PR TITLE
Add a WHERE clause to the oldest_active query

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -294,6 +294,7 @@ class Reports:
                         ORDER BY user_id
                         LIMIT 250
                     ) AS InnerQuery
+                    WHERE user_editcount > 0
                     ORDER BY user_registration
                     LIMIT 200"""
 


### PR DESCRIPTION
Only return users where `user_editcount > 0` — this is unlikely to ever be useful in this report, and is probably an edge case _anyway_.

Query tested at https://quarry.wmcloud.org/query/65208

Fixes #42 